### PR TITLE
Category property export

### DIFF
--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace spec\Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat;
 
-use Closure;
 use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty;
 use PhpSpec\ObjectBehavior;
-
-use function array_diff;
 
 /**
  * @method convert(array $item, array $options = [])

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
@@ -20,7 +20,7 @@ class CategoryPropertySpec extends ObjectBehavior
         $this->shouldHaveType(CategoryProperty::class);
     }
 
-    public function it_flattens_passed_data(): void
+    public function it_flattens_passed_not_localized_data(): void
     {
         $this->convert([
             'some_property' => [
@@ -29,19 +29,7 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'null',
                 ],
             ],
-        ])->shouldMatchArray(['some_property' => 'Some Data']);
-    }
-
-    public function it_handles_null_in_data(): void
-    {
-        $this->convert([
-            'some_property' => [
-                'null' => [
-                    'data' => null,
-                    'locale' => 'null',
-                ],
-            ],
-        ])->shouldMatchArray(['some_property' => '']);
+        ])->shouldBeLike(['some_property' => 'Some Data']);
     }
 
     public function it_flattens_passed_localized_data(): void
@@ -57,7 +45,7 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'en_EN',
                 ],
             ],
-        ])->shouldMatchArray([
+        ])->shouldBeLike([
             'some_property-de_DE' => 'Daten',
             'some_property-en_EN' => 'Some Data',
         ]);
@@ -82,22 +70,22 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'null',
                 ],
             ],
-        ])->shouldMatchArray([
+        ])->shouldBeLike([
             'some_property-de_DE' => 'Daten',
             'some_property-en_EN' => 'Some Data',
             'some_other_property' => 'Extra Property!',
         ]);
     }
 
-    /**
-     * @return Closure[]
-     */
-    public function getMatchers(): array
+    public function it_handles_null_in_data(): void
     {
-        return [
-            'matchArray' => static function ($subject, $value) {
-                return empty(array_diff($subject, $value));
-            },
-        ];
+        $this->convert([
+            'some_property' => [
+                'null' => [
+                    'data' => null,
+                    'locale' => 'null',
+                ],
+            ],
+        ])->shouldBeLike(['some_property' => '']);
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
@@ -26,7 +26,7 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'null',
                 ],
             ],
-        ])->shouldBeLike(['some_property' => 'Some Data']);
+        ])->shouldReturn(['some_property' => 'Some Data']);
     }
 
     public function it_flattens_passed_localized_data(): void
@@ -42,7 +42,7 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'en_EN',
                 ],
             ],
-        ])->shouldBeLike([
+        ])->shouldReturn([
             'some_property-de_DE' => 'Daten',
             'some_property-en_EN' => 'Some Data',
         ]);
@@ -67,7 +67,7 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'null',
                 ],
             ],
-        ])->shouldBeLike([
+        ])->shouldReturn([
             'some_property-de_DE' => 'Daten',
             'some_property-en_EN' => 'Some Data',
             'some_other_property' => 'Extra Property!',
@@ -83,6 +83,6 @@ class CategoryPropertySpec extends ObjectBehavior
                     'locale' => 'null',
                 ],
             ],
-        ])->shouldBeLike(['some_property' => '']);
+        ])->shouldReturn(['some_property' => '']);
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/ArrayConverter/StandardToFlat/CategoryPropertySpec.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat;
+
+use Closure;
+use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty;
+use PhpSpec\ObjectBehavior;
+
+use function array_diff;
+
+/**
+ * @method convert(array $item, array $options = [])
+ */
+class CategoryPropertySpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(CategoryProperty::class);
+    }
+
+    public function it_flattens_passed_data(): void
+    {
+        $this->convert([
+            'some_property' => [
+                'null' => [
+                    'data' => 'Some Data',
+                    'locale' => 'null',
+                ],
+            ],
+        ])->shouldMatchArray(['some_property' => 'Some Data']);
+    }
+
+    public function it_handles_null_in_data(): void
+    {
+        $this->convert([
+            'some_property' => [
+                'null' => [
+                    'data' => null,
+                    'locale' => 'null',
+                ],
+            ],
+        ])->shouldMatchArray(['some_property' => '']);
+    }
+
+    public function it_flattens_passed_localized_data(): void
+    {
+        $this->convert([
+            'some_property' => [
+                'de_DE' => [
+                    'data' => 'Daten',
+                    'locale' => 'de_DE',
+                ],
+                'en_EN' => [
+                    'data' => 'Some Data',
+                    'locale' => 'en_EN',
+                ],
+            ],
+        ])->shouldMatchArray([
+            'some_property-de_DE' => 'Daten',
+            'some_property-en_EN' => 'Some Data',
+        ]);
+    }
+
+    public function it_flattens_passed_mixed_data(): void
+    {
+        $this->convert([
+            'some_property' => [
+                'de_DE' => [
+                    'data' => 'Daten',
+                    'locale' => 'de_DE',
+                ],
+                'en_EN' => [
+                    'data' => 'Some Data',
+                    'locale' => 'en_EN',
+                ],
+            ],
+            'some_other_property' => [
+                'null' => [
+                    'data' => 'Extra Property!',
+                    'locale' => 'null',
+                ],
+            ],
+        ])->shouldMatchArray([
+            'some_property-de_DE' => 'Daten',
+            'some_property-en_EN' => 'Some Data',
+            'some_other_property' => 'Extra Property!',
+        ]);
+    }
+
+    /**
+     * @return Closure[]
+     */
+    public function getMatchers(): array
+    {
+        return [
+            'matchArray' => static function ($subject, $value) {
+                return empty(array_diff($subject, $value));
+            },
+        ];
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Connector\Processor\Normalization;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
+use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
+use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty as StandardToFlatConverter;
+use Flagbit\Bundle\CategoryBundle\Connector\Processor\Normalization\ProcessorDecorator;
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryProperty;
+use Flagbit\Bundle\CategoryBundle\Repository\CategoryPropertyRepository;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @method process($item)
+ */
+class ProcessorDecoratorSpec extends ObjectBehavior
+{
+    public function let(
+        CategoryPropertyRepository $categoryPropertyRepository,
+        NormalizerInterface $normalizer,
+        StandardToFlatConverter $standardToFlat,
+        Processor $inner
+    ): void {
+        $this->beConstructedWith($categoryPropertyRepository, $normalizer, $standardToFlat, $inner);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ProcessorDecorator::class);
+    }
+
+    /**
+     * @throws InvalidItemException
+     * @throws ExceptionInterface
+     */
+    public function it_should_not_merge_properties_if_missing(
+        CategoryInterface $item,
+        CategoryPropertyRepository $categoryPropertyRepository,
+        Processor $inner
+    ): void {
+        $categoryPropertyRepository->findByCategory($item)->willReturn(null);
+
+        $inner->process($item)->willReturn([
+            'code' => 'test',
+            'parent' => 'master',
+            'label' => [
+                'de_DE' => 'Test',
+                'en_EN' => 'Test',
+            ],
+        ]);
+
+        $this->process($item)->shouldBeLike([
+            'code' => 'test',
+            'parent' => 'master',
+            'label' => [
+                'de_DE' => 'Test',
+                'en_EN' => 'Test',
+            ],
+        ]);
+    }
+
+    /**
+     * @throws InvalidItemException
+     */
+    public function it_should_merge_properties_if_available(
+        CategoryInterface $item,
+        CategoryProperty $categoryProperty,
+        CategoryPropertyRepository $categoryPropertyRepository,
+        StandardToFlatConverter $standardToFlat,
+        Processor $inner
+    ): void {
+        $categoryPropertyRepository->findByCategory($item)->willReturn($categoryProperty);
+
+        $categoryProperty->getProperties()->willReturn([]);
+
+        $standardToFlat->convert([])->willReturn(['some' => 'data']);
+
+        $inner->process($item)->willReturn([
+            'code' => 'test',
+            'parent' => 'master',
+            'label' => [
+                'de_DE' => 'Test',
+                'en_EN' => 'Test',
+            ],
+        ]);
+
+        $this->process($item)->shouldBeLike([
+            'code' => 'test',
+            'parent' => 'master',
+            'label' => [
+                'de_DE' => 'Test',
+                'en_EN' => 'Test',
+            ],
+            'some' => 'data',
+        ]);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
@@ -52,7 +52,7 @@ class ProcessorDecoratorSpec extends ObjectBehavior
             ],
         ]);
 
-        $this->process($item)->shouldBeLike([
+        $this->process($item)->shouldReturn([
             'code' => 'test',
             'parent' => 'master',
             'label' => [
@@ -87,7 +87,7 @@ class ProcessorDecoratorSpec extends ObjectBehavior
             ],
         ]);
 
-        $this->process($item)->shouldBeLike([
+        $this->process($item)->shouldReturn([
             'code' => 'test',
             'parent' => 'master',
             'label' => [

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
@@ -13,7 +13,6 @@ use Flagbit\Bundle\CategoryBundle\Entity\CategoryProperty;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryPropertyRepository;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @method process($item)
@@ -22,11 +21,10 @@ class ProcessorDecoratorSpec extends ObjectBehavior
 {
     public function let(
         CategoryPropertyRepository $categoryPropertyRepository,
-        NormalizerInterface $normalizer,
         StandardToFlatConverter $standardToFlat,
         Processor $inner
     ): void {
-        $this->beConstructedWith($categoryPropertyRepository, $normalizer, $standardToFlat, $inner);
+        $this->beConstructedWith($categoryPropertyRepository, $standardToFlat, $inner);
     }
 
     public function it_is_initializable(): void

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
@@ -22,9 +22,9 @@ class ProcessorDecoratorSpec extends ObjectBehavior
     public function let(
         CategoryPropertyRepository $categoryPropertyRepository,
         StandardToFlatConverter $standardToFlat,
-        Processor $inner
+        Processor $baseProcessor
     ): void {
-        $this->beConstructedWith($categoryPropertyRepository, $standardToFlat, $inner);
+        $this->beConstructedWith($categoryPropertyRepository, $standardToFlat, $baseProcessor);
     }
 
     public function it_is_initializable(): void
@@ -39,11 +39,11 @@ class ProcessorDecoratorSpec extends ObjectBehavior
     public function it_should_not_merge_properties_if_missing(
         CategoryInterface $item,
         CategoryPropertyRepository $categoryPropertyRepository,
-        Processor $inner
+        Processor $baseProcessor
     ): void {
         $categoryPropertyRepository->findByCategory($item)->willReturn(null);
 
-        $inner->process($item)->willReturn([
+        $baseProcessor->process($item)->willReturn([
             'code' => 'test',
             'parent' => 'master',
             'label' => [
@@ -70,7 +70,7 @@ class ProcessorDecoratorSpec extends ObjectBehavior
         CategoryProperty $categoryProperty,
         CategoryPropertyRepository $categoryPropertyRepository,
         StandardToFlatConverter $standardToFlat,
-        Processor $inner
+        Processor $baseProcessor
     ): void {
         $categoryPropertyRepository->findByCategory($item)->willReturn($categoryProperty);
 
@@ -78,7 +78,7 @@ class ProcessorDecoratorSpec extends ObjectBehavior
 
         $standardToFlat->convert([])->willReturn(['some' => 'data']);
 
-        $inner->process($item)->willReturn([
+        $baseProcessor->process($item)->willReturn([
             'code' => 'test',
             'parent' => 'master',
             'label' => [

--- a/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
+++ b/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
@@ -27,7 +27,7 @@ class CategoryProperty extends AbstractSimpleArrayConverter
             $locale = $localizedProperty['locale'] ?? '';
             $data   = $localizedProperty['data'] ?? '';
 
-            if (empty($locale) || $locale === 'null') {
+            if ($locale === '' || $locale === 'null') {
                 $convertedItem[$property] = $data;
 
                 continue;

--- a/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
+++ b/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat;
+
+use Akeneo\Tool\Component\Connector\ArrayConverter\StandardToFlat\AbstractSimpleArrayConverter;
+
+use function sprintf;
+
+/**
+ * Array converter to flatten the array from {@link CategoryProperty::$properties}.
+ */
+class CategoryProperty extends AbstractSimpleArrayConverter
+{
+    /**
+     * @param array<string, mixed> $data
+     * @phpstan-param array<string, mixed> $convertedItem
+     * @phpstan-param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    // phpcs:ignore
+    protected function convertProperty($property, $data, $convertedItem, $options): array
+    {
+        foreach ($data as $localizedProperty) {
+            $locale = $localizedProperty['locale'];
+            $data   = $localizedProperty['data'];
+
+            if (empty($locale) || $locale === 'null') {
+                $convertedItem[$property] = $data;
+
+                continue;
+            }
+
+            $localizedKey                 = sprintf('%s-%s', $property, $locale);
+            $convertedItem[$localizedKey] = $data;
+        }
+
+        return $convertedItem;
+    }
+}

--- a/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
+++ b/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
@@ -14,13 +14,13 @@ use function sprintf;
 class CategoryProperty extends AbstractSimpleArrayConverter
 {
     /**
-     * @param array<string, mixed> $data
+     * {@inheritdoc}
+     *
      * @phpstan-param array<string, mixed> $convertedItem
      * @phpstan-param array<string, mixed> $options
      *
      * @return array<string, mixed>
      */
-    // phpcs:ignore
     protected function convertProperty($property, $data, $convertedItem, $options): array
     {
         foreach ($data as $localizedProperty) {

--- a/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
+++ b/src/Connector/ArrayConverter/StandardToFlat/CategoryProperty.php
@@ -24,8 +24,8 @@ class CategoryProperty extends AbstractSimpleArrayConverter
     protected function convertProperty($property, $data, $convertedItem, $options): array
     {
         foreach ($data as $localizedProperty) {
-            $locale = $localizedProperty['locale'];
-            $data   = $localizedProperty['data'];
+            $locale = $localizedProperty['locale'] ?? '';
+            $data   = $localizedProperty['data'] ?? '';
 
             if (empty($locale) || $locale === 'null') {
                 $convertedItem[$property] = $data;

--- a/src/Connector/Processor/Normalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Normalization/ProcessorDecorator.php
@@ -26,16 +26,16 @@ class ProcessorDecorator implements ItemProcessorInterface
 {
     protected CategoryPropertyRepository $categoryPropertyRepository;
     protected StandardToFlatConverter $standardToFlat;
-    protected Processor $inner;
+    protected ItemProcessorInterface $baseProcessor;
 
     public function __construct(
         CategoryPropertyRepository $categoryPropertyRepository,
         StandardToFlatConverter $standardToFlat,
-        Processor $inner
+        ItemProcessorInterface $baseProcessor
     ) {
         $this->categoryPropertyRepository = $categoryPropertyRepository;
         $this->standardToFlat             = $standardToFlat;
-        $this->inner                      = $inner;
+        $this->baseProcessor              = $baseProcessor;
     }
 
     /**
@@ -47,7 +47,7 @@ class ProcessorDecorator implements ItemProcessorInterface
      */
     public function process($item)
     {
-        $categoryData = $this->inner->process($item);
+        $categoryData = $this->baseProcessor->process($item);
 
         $categoryProperties = $this->categoryPropertyRepository->findByCategory($item);
         if ($categoryProperties !== null) {

--- a/src/Connector/Processor/Normalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Normalization/ProcessorDecorator.php
@@ -17,8 +17,8 @@ use function array_merge;
 /**
  * Decorator to add category properties during normalization.
  *
- * This decorator class can be used to decorate Akeneo's normalizer service
- * for the category export. It finds and adds the category properties
+ * This decorator class can be used to decorate Akeneo's processor service
+ * used to normalize data for the category export. It finds and adds the category properties
  * provided by this bundle to the exported category's data.
  *
  * @see Processor

--- a/src/Connector/Processor/Normalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Normalization/ProcessorDecorator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Connector\Processor\Normalization;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
+use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
+use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty as StandardToFlatConverter;
+use Flagbit\Bundle\CategoryBundle\Repository\CategoryPropertyRepository;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+use function array_merge;
+
+/**
+ * Decorator to add category properties during normalization.
+ *
+ * This decorator class can be used to decorate Akeneo's normalizer service
+ * for the category export. It finds and adds the category properties
+ * provided by this bundle to the exported category's data.
+ *
+ * @see Processor
+ */
+class ProcessorDecorator implements ItemProcessorInterface
+{
+    protected NormalizerInterface $normalizer;
+    protected CategoryPropertyRepository $categoryPropertyRepository;
+    protected StandardToFlatConverter $standardToFlat;
+    protected Processor $inner;
+
+    public function __construct(
+        CategoryPropertyRepository $categoryPropertyRepository,
+        NormalizerInterface $normalizer,
+        StandardToFlatConverter $standardToFlat,
+        Processor $inner
+    ) {
+        $this->categoryPropertyRepository = $categoryPropertyRepository;
+        $this->normalizer                 = $normalizer;
+        $this->standardToFlat             = $standardToFlat;
+        $this->inner                      = $inner;
+    }
+
+    /**
+     * @phpstan-param CategoryInterface $item
+     *
+     * @return mixed
+     *
+     * @throws InvalidItemException
+     */
+    public function process($item)
+    {
+        $categoryData = $this->inner->process($item);
+
+        $categoryProperties = $this->categoryPropertyRepository->findByCategory($item);
+        if ($categoryProperties !== null) {
+            $categoryData = array_merge(
+                $categoryData,
+                $this->standardToFlat->convert($categoryProperties->getProperties())
+            );
+        }
+
+        return $categoryData;
+    }
+}

--- a/src/Connector/Processor/Normalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Normalization/ProcessorDecorator.php
@@ -10,7 +10,6 @@ use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
 use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty as StandardToFlatConverter;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryPropertyRepository;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 use function array_merge;
 
@@ -25,19 +24,16 @@ use function array_merge;
  */
 class ProcessorDecorator implements ItemProcessorInterface
 {
-    protected NormalizerInterface $normalizer;
     protected CategoryPropertyRepository $categoryPropertyRepository;
     protected StandardToFlatConverter $standardToFlat;
     protected Processor $inner;
 
     public function __construct(
         CategoryPropertyRepository $categoryPropertyRepository,
-        NormalizerInterface $normalizer,
         StandardToFlatConverter $standardToFlat,
         Processor $inner
     ) {
         $this->categoryPropertyRepository = $categoryPropertyRepository;
-        $this->normalizer                 = $normalizer;
         $this->standardToFlat             = $standardToFlat;
         $this->inner                      = $inner;
     }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -56,6 +56,5 @@ services:
     decoration_inner_name: 'flagbit.category.processor.normalization.category.inner'
     arguments:
       - '@flagbit.category.repository.category_property'
-      - '@pim_internal_api_serializer'
       - '@flagbit.category.converter.standard_to_flat.category_property'
       - '@flagbit.category.processor.normalization.category.inner'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -46,3 +46,17 @@ services:
       - '@doctrine.orm.entity_manager'
     tags:
       - { name: 'kernel.event_listener', event: 'akeneo.storage.post_save', method: 'onCategoryPostSave' }
+
+  flagbit.category.converter.standard_to_flat.category_property:
+    class: 'Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty'
+
+  # Decorate normalizer of category export
+  flagbit.category.processor.normalization.category:
+    class: 'Flagbit\Bundle\CategoryBundle\Connector\Processor\Normalization\ProcessorDecorator'
+    decorates: 'pim_connector.processor.normalization.category'
+    decoration_inner_name: 'flagbit.category.processor.normalization.category.inner'
+    arguments:
+      - '@flagbit.category.repository.category_property'
+      - '@pim_internal_api_serializer'
+      - '@flagbit.category.converter.standard_to_flat.category_property'
+      - '@flagbit.category.processor.normalization.category.inner'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -50,7 +50,6 @@ services:
   flagbit.category.converter.standard_to_flat.category_property:
     class: 'Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty'
 
-  # Decorate normalizer of category export
   flagbit.category.processor.normalization.category:
     class: 'Flagbit\Bundle\CategoryBundle\Connector\Processor\Normalization\ProcessorDecorator'
     decorates: 'pim_connector.processor.normalization.category'


### PR DESCRIPTION
Extend the Akeneo category export to contain the custom properties of this bundle.

Test Cases:
All tests should be run with both CSV and XLSX export.
- Run the category export without defining any properties. The export result equals the result without this bundle.
- Run the category export with some properties. The export now contains the custom properties
  - The custom properties are appended as columns to the exported files
  - The custom properies which are localized follow the same schema as the default label property of Akeneo (`name-xy_XY`)
  - Exported properties are written into the proper column