### PR TITLE
Ignore PHPLint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /config
 /.phpunit.result.cache
 
+# PHPLint
+/.phplint-cache
+
 # Build data
 /build/
 


### PR DESCRIPTION
Update the `.gitignore` to ignore the cache file of PHPLint.