### PR TITLE
Implement data transformers for custom property types

### DIFF
--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Denormalization/ProcessorDecoratorSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Denormalization/ProcessorDecoratorSpec.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Connector\Processor\Denormalization;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
+use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
+use Flagbit\Bundle\CategoryBundle\Connector\Processor\Denormalization\ProcessorDecorator;
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformerManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+
+/**
+ * @method process($item)
+ */
+class ProcessorDecoratorSpec extends ObjectBehavior
+{
+    /**
+     * @param ParameterBag<string, array<string, mixed>> $propertiesBag
+     */
+    public function let(
+        Processor $baseProcessor,
+        DenormalizationTransformerManager $transformerManager,
+        ParameterBag $propertiesBag
+    ): void {
+        $this->beConstructedWith($baseProcessor, $transformerManager, $propertiesBag);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ProcessorDecorator::class);
+    }
+
+    /**
+     * @param ParameterBag<string, array<string, mixed>> $propertiesBag
+     *
+     * @throws InvalidItemException
+     * @throws ExceptionInterface
+     */
+    public function it_not_runs_transformations_without_properties(
+        CategoryInterface $category,
+        Processor $baseProcessor,
+        DenormalizationTransformerManager $transformerManager,
+        ParameterBag $propertiesBag
+    ): void {
+        $baseProcessor->process($category)->willReturn(['code' => 'test']);
+
+        $propertiesBag->all()->willReturn([]);
+        $transformerManager->transformOnDenormalized(Argument::any())->shouldNotBeCalled();
+        $propertiesBag->set(Argument::type('string'), Argument::any())->shouldNotBeCalled();
+
+        $this->process($category)->shouldReturn(['code' => 'test']);
+    }
+
+    /**
+     * @param ParameterBag<string, array<string, mixed>> $propertiesBag
+     *
+     * @throws InvalidItemException
+     */
+    public function it_runs_transformations_when_properties_are_available(
+        CategoryInterface $category,
+        Processor $baseProcessor,
+        DenormalizationTransformerManager $transformerManager,
+        ParameterBag $propertiesBag
+    ): void {
+        $propertiesData            = [
+            'category1' => ['test' => ['null' => ['data' => 'test', 'locale' => 'null']]],
+            'category2' => ['test_2' => ['null' => ['data' => '1', 'locale' => 'null']]],
+        ];
+        $transformedPropertiesData = [
+            ['test' => ['null' => ['data' => 'test', 'locale' => 'null']]],
+            ['test_2' => ['null' => ['data' => 1, 'locale' => 'null']]],
+        ];
+
+        $baseProcessor->process($category)->willReturn(['code' => 'test']);
+
+        $propertiesBag->all()->willReturn($propertiesData);
+        $transformerManager->transformOnDenormalized($propertiesData['category1'])
+            ->willReturn($transformedPropertiesData[0]);
+        $transformerManager->transformOnDenormalized($propertiesData['category2'])
+            ->willReturn($transformedPropertiesData[1]);
+        $propertiesBag->set('category1', $transformedPropertiesData[0])
+            ->shouldBeCalled();
+        $propertiesBag->set('category2', $transformedPropertiesData[1])
+            ->shouldBeCalled();
+
+        $this->process($category)->shouldReturn(['code' => 'test']);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Connector/Processor/Normalization/ProcessorDecoratorSpec.php
@@ -11,6 +11,7 @@ use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\Catego
 use Flagbit\Bundle\CategoryBundle\Connector\Processor\Normalization\ProcessorDecorator;
 use Flagbit\Bundle\CategoryBundle\Entity\CategoryProperty;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryPropertyRepository;
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformerManager;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
@@ -22,9 +23,10 @@ class ProcessorDecoratorSpec extends ObjectBehavior
     public function let(
         CategoryPropertyRepository $categoryPropertyRepository,
         StandardToFlatConverter $standardToFlat,
-        Processor $baseProcessor
+        Processor $baseProcessor,
+        NormalizationTransformerManager $transformerManager
     ): void {
-        $this->beConstructedWith($categoryPropertyRepository, $standardToFlat, $baseProcessor);
+        $this->beConstructedWith($categoryPropertyRepository, $standardToFlat, $baseProcessor, $transformerManager);
     }
 
     public function it_is_initializable(): void
@@ -70,11 +72,16 @@ class ProcessorDecoratorSpec extends ObjectBehavior
         CategoryProperty $categoryProperty,
         CategoryPropertyRepository $categoryPropertyRepository,
         StandardToFlatConverter $standardToFlat,
-        Processor $baseProcessor
+        Processor $baseProcessor,
+        NormalizationTransformerManager $transformerManager
     ): void {
         $categoryPropertyRepository->findByCategory($item)->willReturn($categoryProperty);
 
         $categoryProperty->getProperties()->willReturn([]);
+
+        $transformerManager->transformOnNormalized([])
+            ->shouldNotHaveBeenCalled()
+            ->willReturn([]);
 
         $standardToFlat->convert([])->willReturn(['some' => 'data']);
 

--- a/spec/Flagbit/Bundle/CategoryBundle/DependencyInjection/CompilerPass/DataTransformerCompilerPassSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/DependencyInjection/CompilerPass/DataTransformerCompilerPassSpec.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\DependencyInjection\CompilerPass;
+
+use Flagbit\Bundle\CategoryBundle\DependencyInjection\CompilerPass\DataTransformerCompilerPass;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @method process(ContainerBuilder $container)
+ */
+class DataTransformerCompilerPassSpec extends ObjectBehavior
+{
+    public function it_is_initialiable(): void
+    {
+        $this->shouldHaveType(DataTransformerCompilerPass::class);
+    }
+
+    public function it_has_no_transformer_managers(ContainerBuilder $container): void
+    {
+        $container->has('flagbit.category.data_transformer.normalization_transformer_manager')->willReturn(false);
+        $container->has('flagbit.category.data_transformer.denormalization_transformer_manager')->willReturn(false);
+
+        $container->findDefinition(Argument::any())->shouldNotBeCalled();
+        $container->findTaggedServiceIds(Argument::any())->shouldNotBeCalled();
+        $container->findDefinition(Argument::any())->shouldNotBeCalled();
+
+        $this->process($container);
+    }
+
+    public function it_prepares_normalization_transformer_manager(
+        ContainerBuilder $container,
+        Definition $normalizationTransformerManagerDefinition
+    ): void {
+        $container->has('flagbit.category.data_transformer.normalization_transformer_manager')->willReturn(true);
+        $container->has('flagbit.category.data_transformer.denormalization_transformer_manager')->willReturn(false);
+
+        $container->findDefinition('flagbit.category.data_transformer.denormalization_transformer_manager')
+            ->shouldNotBeCalled();
+        $container->findDefinition('flagbit.category.data_transformer.normalization_transformer_manager')
+            ->willReturn($normalizationTransformerManagerDefinition);
+
+        $container->findTaggedServiceIds('flagbit.category.data_transformer.denormalization')->shouldNotBeCalled();
+        $container->findTaggedServiceIds('flagbit.category.data_transformer.normalization')
+            ->willReturn([
+                'flagbit.category.data_transformer.normalization.default' => [
+                    'flagbit.category.data_transformer.normalization' => ['type' => 'default'],
+                ],
+                'flagbit.category.data_transformer.normalization.checkbox' => [
+                    'flagbit.category.data_transformer.normalization' => ['type' => 'checkbox'],
+                ],
+            ]);
+        $normalizationTransformerManagerDefinition->addMethodCall(
+            'addTransformer',
+            Argument::that(static function (array $args): bool {
+                return $args[0] instanceof Reference && ($args[1] === 'default' || $args[1] === 'checkbox');
+            })
+        )->shouldBeCalledTimes(2);
+
+        $this->process($container);
+    }
+
+    public function it_prepares_denormalization_transformer_manager(
+        ContainerBuilder $container,
+        Definition $denormalizationTransformerManagerDefinition
+    ): void {
+        $container->has('flagbit.category.data_transformer.normalization_transformer_manager')->willReturn(false);
+        $container->has('flagbit.category.data_transformer.denormalization_transformer_manager')->willReturn(true);
+
+        $container->findDefinition('flagbit.category.data_transformer.normalization_transformer_manager')
+            ->shouldNotBeCalled();
+        $container->findDefinition('flagbit.category.data_transformer.denormalization_transformer_manager')
+            ->willReturn($denormalizationTransformerManagerDefinition);
+
+        $container->findTaggedServiceIds('flagbit.category.data_transformer.normalization')->shouldNotBeCalled();
+        $container->findTaggedServiceIds('flagbit.category.data_transformer.denormalization')
+            ->willReturn([
+                'flagbit.category.data_transformer.denormalization.default' => [
+                    'flagbit.category.data_transformer.denormalization' => ['type' => 'default'],
+                ],
+                'flagbit.category.data_transformer.denormalization.checkbox' => [
+                    'flagbit.category.data_transformer.denormalization' => ['type' => 'checkbox'],
+                ],
+            ]);
+
+        $denormalizationTransformerManagerDefinition->addMethodCall(
+            'addTransformer',
+            Argument::that(static function (array $args): bool {
+                return $args[0] instanceof Reference && ($args[1] === 'default' || $args[1] === 'checkbox');
+            })
+        )->shouldBeCalledTimes(2);
+
+        $this->process($container);
+    }
+
+    public function it_prepares_both_transformer_manager(
+        ContainerBuilder $container,
+        Definition $normalizationTransformerManagerDefinition,
+        Definition $denormalizationTransformerManagerDefinition
+    ): void {
+        $container->has('flagbit.category.data_transformer.normalization_transformer_manager')->willReturn(true);
+        $container->has('flagbit.category.data_transformer.denormalization_transformer_manager')->willReturn(true);
+
+        $container->findDefinition('flagbit.category.data_transformer.denormalization_transformer_manager')
+            ->willReturn($denormalizationTransformerManagerDefinition);
+        $container->findDefinition('flagbit.category.data_transformer.normalization_transformer_manager')
+            ->willReturn($normalizationTransformerManagerDefinition);
+
+        $container->findTaggedServiceIds('flagbit.category.data_transformer.denormalization')
+            ->willReturn([
+                'flagbit.category.data_transformer.denormalization.default' => [
+                    'flagbit.category.data_transformer.denormalization' => ['type' => 'default'],
+                ],
+                'flagbit.category.data_transformer.denormalization.checkbox' => [
+                    'flagbit.category.data_transformer.denormalization' => ['type' => 'checkbox'],
+                ],
+            ]);
+        $container->findTaggedServiceIds('flagbit.category.data_transformer.normalization')
+            ->willReturn([
+                'flagbit.category.data_transformer.normalization.default' => [
+                    'flagbit.category.data_transformer.normalization' => ['type' => 'default'],
+                ],
+                'flagbit.category.data_transformer.normalization.checkbox' => [
+                    'flagbit.category.data_transformer.normalization' => ['type' => 'checkbox'],
+                ],
+            ]);
+
+        $denormalizationTransformerManagerDefinition->addMethodCall(
+            'addTransformer',
+            Argument::that(static function (array $args): bool {
+                return $args[0] instanceof Reference && ($args[1] === 'default' || $args[1] === 'checkbox');
+            })
+        )->shouldBeCalledTimes(2);
+        $normalizationTransformerManagerDefinition->addMethodCall(
+            'addTransformer',
+            Argument::that(static function (array $args): bool {
+                return $args[0] instanceof Reference && ($args[1] === 'default' || $args[1] === 'checkbox');
+            })
+        )->shouldBeCalledTimes(2);
+
+        $this->process($container);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/FlagbitCategoryBundleSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/FlagbitCategoryBundleSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle;
+
+use Flagbit\Bundle\CategoryBundle\DependencyInjection\CompilerPass\DataTransformerCompilerPass;
+use Flagbit\Bundle\CategoryBundle\FlagbitCategoryBundle;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @method build(ContainerBuilder $containerBuilder)
+ */
+class FlagbitCategoryBundleSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(FlagbitCategoryBundle::class);
+    }
+
+    public function it_should_be_build_with_data_transformer_compiler_pass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(Argument::type(DataTransformerCompilerPass::class))->shouldBeCalledOnce();
+
+        $this->build($container);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Repository/CategoryConfigRepositorySpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Repository/CategoryConfigRepositorySpec.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace spec\Flagbit\Bundle\CategoryBundle\Repository;
 
+use Closure;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
+/**
+ * @method findConfig(int $identity = 1)
+ */
 class CategoryConfigRepositorySpec extends ObjectBehavior
 {
     public function let(EntityManagerInterface $em, ClassMetadata $class): void
@@ -19,5 +25,42 @@ class CategoryConfigRepositorySpec extends ObjectBehavior
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(CategoryConfigRepository::class);
+    }
+
+    public function it_should_return_new_config_when_not_found(EntityManagerInterface $em): void
+    {
+        $em->find(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(null);
+
+        $this->findConfig()->shouldEqualConfig([]);
+    }
+
+    public function it_should_try_to_find_config_with_specified_id(
+        EntityManagerInterface $em,
+        CategoryConfig $categoryConfig
+    ): void {
+        $em->find(Argument::any(), 42, Argument::any(), Argument::any())->willReturn($categoryConfig);
+
+        $this->findConfig(42)->shouldReturn($categoryConfig);
+    }
+
+    public function it_should_try_to_find_config_with_default_id(
+        EntityManagerInterface $em,
+        CategoryConfig $categoryConfig
+    ): void {
+        $em->find(Argument::any(), 1, Argument::any(), Argument::any())->willReturn($categoryConfig);
+
+        $this->findConfig()->shouldReturn($categoryConfig);
+    }
+
+    /**
+     * @return Closure[]
+     */
+    public function getMatchers(): array
+    {
+        return [
+            'equalConfig' => static function (CategoryConfig $subject, array $value) {
+                return $subject->getConfig() === $value;
+            },
+        ];
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/BooleanTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/BooleanTransformerSpec.php
@@ -17,68 +17,33 @@ class BooleanTransformerSpec extends ObjectBehavior
         $this->shouldHaveType(BooleanTransformer::class);
     }
 
-    public function it_returns_one_with_boolean_true_data_argument(): void
+    public function it_returns_true_with_boolean_true_data_argument(): void
     {
-        $this->transform(true)->shouldReturn(1);
+        $this->transform(true)->shouldReturn(true);
     }
 
-    public function it_returns_zero_with_boolean_false_data_argument(): void
+    public function it_returns_false_with_boolean_false_data_argument(): void
     {
-        $this->transform(false)->shouldReturn(0);
+        $this->transform(false)->shouldReturn(false);
     }
 
-    public function it_returns_one_with_int_one_data_argument(): void
+    public function it_returns_true_with_int_one_data_argument(): void
     {
-        $this->transform(1)->shouldReturn(1);
+        $this->transform(1)->shouldReturn(true);
     }
 
-    public function it_returns_zero_with_int_zero_data_argument(): void
+    public function it_returns_false_with_int_zero_data_argument(): void
     {
-        $this->transform(0)->shouldReturn(0);
+        $this->transform(0)->shouldReturn(false);
     }
 
-    public function it_returns_one_with_int_five_data_argument(): void
+    public function it_returns_true_with_string_one_data_argument(): void
     {
-        $this->transform(5)->shouldReturn(1);
+        $this->transform('1')->shouldReturn(true);
     }
 
-    public function it_returns_one_with_int_minus_one_data_argument(): void
+    public function it_returns_false_with_string_zero_data_argument(): void
     {
-        $this->transform(-1)->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_string_one_data_argument(): void
-    {
-        $this->transform('1')->shouldReturn(1);
-    }
-
-    public function it_returns_zero_with_string_zero_data_argument(): void
-    {
-        $this->transform('0')->shouldReturn(0);
-    }
-
-    public function it_returns_one_with_string_data_argument(): void
-    {
-        $this->transform('test')->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_string_space_data_argument(): void
-    {
-        $this->transform(' ')->shouldReturn(1);
-    }
-
-    public function it_returns_zero_with_string_empty_data_argument(): void
-    {
-        $this->transform('')->shouldReturn(0);
-    }
-
-    public function it_returns_one_with_array_with_elements_data_argument(): void
-    {
-        $this->transform(['test'])->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_array_empty_data_argument(): void
-    {
-        $this->transform([])->shouldReturn(0);
+        $this->transform('0')->shouldReturn(false);
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/BooleanTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/BooleanTransformerSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Transformer\Denormalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\BooleanTransformer;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @method transform(mixed $data)
+ */
+class BooleanTransformerSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(BooleanTransformer::class);
+    }
+
+    public function it_returns_one_with_boolean_true_data_argument(): void
+    {
+        $this->transform(true)->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_boolean_false_data_argument(): void
+    {
+        $this->transform(false)->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_int_one_data_argument(): void
+    {
+        $this->transform(1)->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_int_zero_data_argument(): void
+    {
+        $this->transform(0)->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_int_five_data_argument(): void
+    {
+        $this->transform(5)->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_int_minus_one_data_argument(): void
+    {
+        $this->transform(-1)->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_string_one_data_argument(): void
+    {
+        $this->transform('1')->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_string_zero_data_argument(): void
+    {
+        $this->transform('0')->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_string_data_argument(): void
+    {
+        $this->transform('test')->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_string_space_data_argument(): void
+    {
+        $this->transform(' ')->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_string_empty_data_argument(): void
+    {
+        $this->transform('')->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_array_with_elements_data_argument(): void
+    {
+        $this->transform(['test'])->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_array_empty_data_argument(): void
+    {
+        $this->transform([])->shouldReturn(0);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/DefaultTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/DefaultTransformerSpec.php
@@ -17,23 +17,8 @@ class DefaultTransformerSpec extends ObjectBehavior
         $this->shouldHaveType(DefaultTransformer::class);
     }
 
-    public function it_returns_unmodified_value_with_string_data_argument(): void
+    public function it_returns_unmodified_value(): void
     {
         $this->transform('some test')->shouldReturn('some test');
-    }
-
-    public function it_returns_unmodified_value_with_int_data_argument(): void
-    {
-        $this->transform(5)->shouldReturn(5);
-    }
-
-    public function it_returns_unmodified_value_with_boolean_data_argument(): void
-    {
-        $this->transform(true)->shouldReturn(true);
-    }
-
-    public function it_returns_unmodified_value_with_array_data_argument(): void
-    {
-        $this->transform(['test' => 5])->shouldReturn(['test' => 5]);
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/DefaultTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Denormalization/DefaultTransformerSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Transformer\Denormalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\DefaultTransformer;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @method transform(mixed $data)
+ */
+class DefaultTransformerSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(DefaultTransformer::class);
+    }
+
+    public function it_returns_unmodified_value_with_string_data_argument(): void
+    {
+        $this->transform('some test')->shouldReturn('some test');
+    }
+
+    public function it_returns_unmodified_value_with_int_data_argument(): void
+    {
+        $this->transform(5)->shouldReturn(5);
+    }
+
+    public function it_returns_unmodified_value_with_boolean_data_argument(): void
+    {
+        $this->transform(true)->shouldReturn(true);
+    }
+
+    public function it_returns_unmodified_value_with_array_data_argument(): void
+    {
+        $this->transform(['test' => 5])->shouldReturn(['test' => 5]);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/DenormalizationTransformerManagerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/DenormalizationTransformerManagerSpec.php
@@ -35,34 +35,10 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([]);
-        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
-
-        // Add transformers
-        $this->addTransformer(
-            $defaultTransformer,
-            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
-        );
-        $this->addTransformer(
-            $booleanTransformer,
-            'checkbox'
-        );
-
-        // Actual test call
-        $this->transformOnDenormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
-            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
-    }
-
-    public function it_skips_transformers_if_no_category_properties_exist(
-        CategoryConfigRepository $categoryConfigRepository,
-        DefaultTransformer $defaultTransformer,
-        BooleanTransformer $booleanTransformer
-    ): void {
-        $categoryConfigRepository->find(1)
-            ->willReturn(null);
 
         $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
 
@@ -87,7 +63,7 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([
@@ -120,7 +96,7 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([
@@ -128,9 +104,9 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         ]);
 
         $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
-        $booleanTransformer->transform('')
+        $booleanTransformer->transform('0')
             ->shouldBeCalled()
-            ->willReturn(0);
+            ->willReturn(false);
 
         // Add transformers
         $this->addTransformer(
@@ -143,8 +119,8 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         );
 
         // Actual test call
-        $this->transformOnDenormalized(['test' => ['null' => ['data' => '', 'locale' => 'null']]])
-            ->shouldReturn(['test' => ['null' => ['data' => 0, 'locale' => 'null']]]);
+        $this->transformOnDenormalized(['test' => ['null' => ['data' => '0', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => false, 'locale' => 'null']]]);
     }
 
     public function it_runs_transformations_with_mixed_transformers(
@@ -153,7 +129,7 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([
@@ -164,9 +140,9 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         $defaultTransformer->transform('test')
             ->shouldBeCalled()
             ->willReturnArgument();
-        $booleanTransformer->transform('')
+        $booleanTransformer->transform('0')
             ->shouldBeCalled()
-            ->willReturn(0);
+            ->willReturn(false);
 
         // Add transformers
         $this->addTransformer(
@@ -181,10 +157,10 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         // Actual test call
         $this->transformOnDenormalized([
             'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
-            'test2' => ['null' => ['data' => '', 'locale' => 'null']],
+            'test2' => ['null' => ['data' => '0', 'locale' => 'null']],
         ])->shouldReturn([
             'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
-            'test2' => ['null' => ['data' => 0, 'locale' => 'null']],
+            'test2' => ['null' => ['data' => false, 'locale' => 'null']],
         ]);
     }
 
@@ -194,7 +170,7 @@ class DenormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/DenormalizationTransformerManagerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/DenormalizationTransformerManagerSpec.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Transformer;
+
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
+use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
+use Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\BooleanTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\DefaultTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformerManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @method addTransformer(DenormalizationTransformer $transformer, string $type)
+ * @method transformOnDenormalized(array $properties)
+ */
+class DenormalizationTransformerManagerSpec extends ObjectBehavior
+{
+    public function let(CategoryConfigRepository $categoryConfigRepository): void
+    {
+        $this->beConstructedWith($categoryConfigRepository);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(DenormalizationTransformerManager::class);
+    }
+
+    public function it_skips_transformers_if_no_category_properties_configured(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([]);
+        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnDenormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
+    }
+
+    public function it_skips_transformers_if_no_category_properties_exist(
+        CategoryConfigRepository $categoryConfigRepository,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn(null);
+
+        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnDenormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
+    }
+
+    public function it_runs_transformations_with_default_transformer(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'text'],
+        ]);
+
+        $booleanTransformer->transform(Argument::any())->shouldNotBeCalled();
+        $defaultTransformer->transform('test')
+            ->shouldBeCalled()
+            ->willReturnArgument();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnDenormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
+    }
+
+    public function it_runs_transformations_with_custom_transformer(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'checkbox'],
+        ]);
+
+        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
+        $booleanTransformer->transform('')
+            ->shouldBeCalled()
+            ->willReturn(0);
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnDenormalized(['test' => ['null' => ['data' => '', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 0, 'locale' => 'null']]]);
+    }
+
+    public function it_runs_transformations_with_mixed_transformers(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'text'],
+            'test2' => ['type' => 'checkbox'],
+        ]);
+
+        $defaultTransformer->transform('test')
+            ->shouldBeCalled()
+            ->willReturnArgument();
+        $booleanTransformer->transform('')
+            ->shouldBeCalled()
+            ->willReturn(0);
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnDenormalized([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+            'test2' => ['null' => ['data' => '', 'locale' => 'null']],
+        ])->shouldReturn([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+            'test2' => ['null' => ['data' => 0, 'locale' => 'null']],
+        ]);
+    }
+
+    public function it_skips_configured_properties_which_are_not_in_data(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'text'],
+            'test2' => ['type' => 'checkbox'],
+        ]);
+
+        $defaultTransformer->transform('test')
+            ->shouldBeCalled()
+            ->willReturnArgument();
+        $booleanTransformer->transform(Argument::any())
+            ->shouldNotBeCalled();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            DenormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnDenormalized([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+        ])->shouldReturn([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+        ]);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/BooleanTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/BooleanTransformerSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Transformer\Normalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\Normalization\BooleanTransformer;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @method transform(mixed $data)
+ */
+class BooleanTransformerSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(BooleanTransformer::class);
+    }
+
+    public function it_returns_one_with_boolean_true_data_argument(): void
+    {
+        $this->transform(true)->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_boolean_false_data_argument(): void
+    {
+        $this->transform(false)->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_int_one_data_argument(): void
+    {
+        $this->transform(1)->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_int_zero_data_argument(): void
+    {
+        $this->transform(0)->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_int_five_data_argument(): void
+    {
+        $this->transform(5)->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_int_minus_one_data_argument(): void
+    {
+        $this->transform(-1)->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_string_one_data_argument(): void
+    {
+        $this->transform('1')->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_string_zero_data_argument(): void
+    {
+        $this->transform('0')->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_string_data_argument(): void
+    {
+        $this->transform('test')->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_string_space_data_argument(): void
+    {
+        $this->transform(' ')->shouldReturn(1);
+    }
+
+    public function it_returns_zero_with_string_empty_data_argument(): void
+    {
+        $this->transform('')->shouldReturn(0);
+    }
+
+    public function it_returns_one_with_array_with_elements_data_argument(): void
+    {
+        $this->transform(['test'])->shouldReturn(1);
+    }
+
+    public function it_returns_one_with_array_empty_data_argument(): void
+    {
+        $this->transform([])->shouldReturn(0);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/BooleanTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/BooleanTransformerSpec.php
@@ -19,66 +19,11 @@ class BooleanTransformerSpec extends ObjectBehavior
 
     public function it_returns_one_with_boolean_true_data_argument(): void
     {
-        $this->transform(true)->shouldReturn(1);
+        $this->transform(true)->shouldReturn('1');
     }
 
     public function it_returns_zero_with_boolean_false_data_argument(): void
     {
-        $this->transform(false)->shouldReturn(0);
-    }
-
-    public function it_returns_one_with_int_one_data_argument(): void
-    {
-        $this->transform(1)->shouldReturn(1);
-    }
-
-    public function it_returns_zero_with_int_zero_data_argument(): void
-    {
-        $this->transform(0)->shouldReturn(0);
-    }
-
-    public function it_returns_one_with_int_five_data_argument(): void
-    {
-        $this->transform(5)->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_int_minus_one_data_argument(): void
-    {
-        $this->transform(-1)->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_string_one_data_argument(): void
-    {
-        $this->transform('1')->shouldReturn(1);
-    }
-
-    public function it_returns_zero_with_string_zero_data_argument(): void
-    {
-        $this->transform('0')->shouldReturn(0);
-    }
-
-    public function it_returns_one_with_string_data_argument(): void
-    {
-        $this->transform('test')->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_string_space_data_argument(): void
-    {
-        $this->transform(' ')->shouldReturn(1);
-    }
-
-    public function it_returns_zero_with_string_empty_data_argument(): void
-    {
-        $this->transform('')->shouldReturn(0);
-    }
-
-    public function it_returns_one_with_array_with_elements_data_argument(): void
-    {
-        $this->transform(['test'])->shouldReturn(1);
-    }
-
-    public function it_returns_one_with_array_empty_data_argument(): void
-    {
-        $this->transform([])->shouldReturn(0);
+        $this->transform(false)->shouldReturn('0');
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/DefaultTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/DefaultTransformerSpec.php
@@ -20,8 +20,5 @@ class DefaultTransformerSpec extends ObjectBehavior
     public function it_returns_unmodified_value(): void
     {
         $this->transform('some test')->shouldReturn('some test');
-        $this->transform(5)->shouldReturn(5);
-        $this->transform(true)->shouldReturn(true);
-        $this->transform(['test' => 5])->shouldReturn(['test' => 5]);
     }
 }

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/DefaultTransformerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/Normalization/DefaultTransformerSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Transformer\Normalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\Normalization\DefaultTransformer;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @method transform(mixed $data)
+ */
+class DefaultTransformerSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(DefaultTransformer::class);
+    }
+
+    public function it_returns_unmodified_value(): void
+    {
+        $this->transform('some test')->shouldReturn('some test');
+        $this->transform(5)->shouldReturn(5);
+        $this->transform(true)->shouldReturn(true);
+        $this->transform(['test' => 5])->shouldReturn(['test' => 5]);
+    }
+}

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/NormalizationTransformerManagerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/NormalizationTransformerManagerSpec.php
@@ -35,35 +35,10 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([]);
-        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
-
-        // Add transformers
-        $this->addTransformer(
-            $defaultTransformer,
-            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
-        );
-        $this->addTransformer(
-            $booleanTransformer,
-            'checkbox'
-        );
-
-        // Actual test call
-        $this->transformOnNormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
-            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
-    }
-
-    public function it_skips_transformers_if_no_category_properties_exist(
-        CategoryConfigRepository $categoryConfigRepository,
-        DefaultTransformer $defaultTransformer,
-        BooleanTransformer $booleanTransformer
-    ): void {
-        $categoryConfigRepository->find(1)
-            ->willReturn(null);
-
         $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
 
         // Add transformers
@@ -87,7 +62,7 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([
@@ -120,7 +95,7 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([
@@ -128,9 +103,9 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         ]);
 
         $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
-        $booleanTransformer->transform('')
+        $booleanTransformer->transform(false)
             ->shouldBeCalled()
-            ->willReturn(0);
+            ->willReturn('0');
 
         // Add transformers
         $this->addTransformer(
@@ -143,8 +118,8 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         );
 
         // Actual test call
-        $this->transformOnNormalized(['test' => ['null' => ['data' => '', 'locale' => 'null']]])
-            ->shouldReturn(['test' => ['null' => ['data' => 0, 'locale' => 'null']]]);
+        $this->transformOnNormalized(['test' => ['null' => ['data' => false, 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => '0', 'locale' => 'null']]]);
     }
 
     public function it_runs_transformations_with_mixed_transformers(
@@ -153,7 +128,7 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([
@@ -164,9 +139,9 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         $defaultTransformer->transform('test')
             ->shouldBeCalled()
             ->willReturnArgument();
-        $booleanTransformer->transform('')
+        $booleanTransformer->transform(false)
             ->shouldBeCalled()
-            ->willReturn(0);
+            ->willReturn('0');
 
         // Add transformers
         $this->addTransformer(
@@ -181,10 +156,10 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         // Actual test call
         $this->transformOnNormalized([
             'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
-            'test2' => ['null' => ['data' => '', 'locale' => 'null']],
+            'test2' => ['null' => ['data' => false, 'locale' => 'null']],
         ])->shouldReturn([
             'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
-            'test2' => ['null' => ['data' => 0, 'locale' => 'null']],
+            'test2' => ['null' => ['data' => '0', 'locale' => 'null']],
         ]);
     }
 
@@ -194,7 +169,7 @@ class NormalizationTransformerManagerSpec extends ObjectBehavior
         DefaultTransformer $defaultTransformer,
         BooleanTransformer $booleanTransformer
     ): void {
-        $categoryConfigRepository->find(1)
+        $categoryConfigRepository->findConfig()
             ->willReturn($categoryConfig);
 
         $categoryConfig->getConfig()->willReturn([

--- a/spec/Flagbit/Bundle/CategoryBundle/Transformer/NormalizationTransformerManagerSpec.php
+++ b/spec/Flagbit/Bundle/CategoryBundle/Transformer/NormalizationTransformerManagerSpec.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Flagbit\Bundle\CategoryBundle\Transformer;
+
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
+use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
+use Flagbit\Bundle\CategoryBundle\Transformer\Normalization\BooleanTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\Normalization\DefaultTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformerManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @method addTransformer(NormalizationTransformer $transformer, string $type)
+ * @method transformOnNormalized(array $properties)
+ */
+class NormalizationTransformerManagerSpec extends ObjectBehavior
+{
+    public function let(CategoryConfigRepository $categoryConfigRepository): void
+    {
+        $this->beConstructedWith($categoryConfigRepository);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(NormalizationTransformerManager::class);
+    }
+
+    public function it_skips_transformers_if_no_category_properties_configured(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([]);
+        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnNormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
+    }
+
+    public function it_skips_transformers_if_no_category_properties_exist(
+        CategoryConfigRepository $categoryConfigRepository,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn(null);
+
+        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnNormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
+    }
+
+    public function it_runs_transformations_with_default_transformer(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'text'],
+        ]);
+
+        $booleanTransformer->transform(Argument::any())->shouldNotBeCalled();
+        $defaultTransformer->transform('test')
+            ->shouldBeCalled()
+            ->willReturnArgument();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnNormalized(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 'test', 'locale' => 'null']]]);
+    }
+
+    public function it_runs_transformations_with_custom_transformer(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'checkbox'],
+        ]);
+
+        $defaultTransformer->transform(Argument::any())->shouldNotBeCalled();
+        $booleanTransformer->transform('')
+            ->shouldBeCalled()
+            ->willReturn(0);
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnNormalized(['test' => ['null' => ['data' => '', 'locale' => 'null']]])
+            ->shouldReturn(['test' => ['null' => ['data' => 0, 'locale' => 'null']]]);
+    }
+
+    public function it_runs_transformations_with_mixed_transformers(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'text'],
+            'test2' => ['type' => 'checkbox'],
+        ]);
+
+        $defaultTransformer->transform('test')
+            ->shouldBeCalled()
+            ->willReturnArgument();
+        $booleanTransformer->transform('')
+            ->shouldBeCalled()
+            ->willReturn(0);
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnNormalized([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+            'test2' => ['null' => ['data' => '', 'locale' => 'null']],
+        ])->shouldReturn([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+            'test2' => ['null' => ['data' => 0, 'locale' => 'null']],
+        ]);
+    }
+
+    public function it_skips_configured_properties_which_are_not_in_data(
+        CategoryConfigRepository $categoryConfigRepository,
+        CategoryConfig $categoryConfig,
+        DefaultTransformer $defaultTransformer,
+        BooleanTransformer $booleanTransformer
+    ): void {
+        $categoryConfigRepository->find(1)
+            ->willReturn($categoryConfig);
+
+        $categoryConfig->getConfig()->willReturn([
+            'test' => ['type' => 'text'],
+            'test2' => ['type' => 'checkbox'],
+        ]);
+
+        $defaultTransformer->transform('test')
+            ->shouldBeCalled()
+            ->willReturnArgument();
+        $booleanTransformer->transform(Argument::any())
+            ->shouldNotBeCalled();
+
+        // Add transformers
+        $this->addTransformer(
+            $defaultTransformer,
+            NormalizationTransformerManager::DEFAULT_NORMALIZATION_TRANSFORMER
+        );
+        $this->addTransformer(
+            $booleanTransformer,
+            'checkbox'
+        );
+
+        // Actual test call
+        $this->transformOnNormalized([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+        ])->shouldReturn([
+            'test' => ['null' => ['data' => 'test', 'locale' => 'null']],
+        ]);
+    }
+}

--- a/src/Connector/Processor/Denormalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Denormalization/ProcessorDecorator.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Connector\Processor\Denormalization;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
+use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformerManager;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+use function array_merge;
+
+/**
+ * Decorator to transform category properties during denormalization.
+ *
+ * This decorator class can be used to decorate Akeneo's processor service
+ * used to denormalize data for the category import.
+ * It runs the defined transformers for the available category properties.
+ *
+ * @see Processor
+ */
+class ProcessorDecorator implements ItemProcessorInterface
+{
+    protected ItemProcessorInterface $baseProcessor;
+    protected DenormalizationTransformerManager $transformerManager;
+    /** @var ParameterBag<string, array<string, mixed>> */
+    private ParameterBag $propertiesBag;
+
+    /**
+     * @param ParameterBag<string, array<string, mixed>> $propertiesBag
+     */
+    public function __construct(
+        ItemProcessorInterface $baseProcessor,
+        DenormalizationTransformerManager $transformerManager,
+        ParameterBag $propertiesBag
+    ) {
+        $this->baseProcessor      = $baseProcessor;
+        $this->transformerManager = $transformerManager;
+        $this->propertiesBag      = $propertiesBag;
+    }
+
+    /**
+     * @phpstan-param CategoryInterface $item
+     *
+     * @return mixed
+     *
+     * @throws InvalidItemException
+     */
+    public function process($item)
+    {
+        $originalResult = $this->baseProcessor->process($item);
+
+        foreach ($this->propertiesBag->all() as $code => $properties) {
+            $this->propertiesBag->set($code, $this->transformerManager->transformOnDenormalized($properties));
+        }
+
+        return $originalResult;
+    }
+}

--- a/src/Connector/Processor/Denormalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Denormalization/ProcessorDecorator.php
@@ -11,8 +11,6 @@ use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
 use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformerManager;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-use function array_merge;
-
 /**
  * Decorator to transform category properties during denormalization.
  *

--- a/src/Connector/Processor/Normalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Normalization/ProcessorDecorator.php
@@ -33,11 +33,13 @@ class ProcessorDecorator implements ItemProcessorInterface
     public function __construct(
         CategoryPropertyRepository $categoryPropertyRepository,
         StandardToFlatConverter $standardToFlat,
-        ItemProcessorInterface $baseProcessor
+        ItemProcessorInterface $baseProcessor,
+        NormalizationTransformerManager $transformerManager
     ) {
         $this->categoryPropertyRepository = $categoryPropertyRepository;
         $this->standardToFlat             = $standardToFlat;
         $this->baseProcessor              = $baseProcessor;
+        $this->transformerManager         = $transformerManager;
     }
 
     /**
@@ -55,8 +57,8 @@ class ProcessorDecorator implements ItemProcessorInterface
         if ($categoryProperties !== null) {
             $categoryData = array_merge(
                 $categoryData,
-                $this->transformerManager->transformOnNormalized(
-                    $this->standardToFlat->convert($categoryProperties->getProperties())
+                $this->standardToFlat->convert(
+                    $this->transformerManager->transformOnNormalized($categoryProperties->getProperties())
                 )
             );
         }

--- a/src/Connector/Processor/Normalization/ProcessorDecorator.php
+++ b/src/Connector/Processor/Normalization/ProcessorDecorator.php
@@ -10,6 +10,7 @@ use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Tool\Component\Connector\Processor\Normalization\Processor;
 use Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\StandardToFlat\CategoryProperty as StandardToFlatConverter;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryPropertyRepository;
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformerManager;
 
 use function array_merge;
 
@@ -27,6 +28,7 @@ class ProcessorDecorator implements ItemProcessorInterface
     protected CategoryPropertyRepository $categoryPropertyRepository;
     protected StandardToFlatConverter $standardToFlat;
     protected ItemProcessorInterface $baseProcessor;
+    protected NormalizationTransformerManager $transformerManager;
 
     public function __construct(
         CategoryPropertyRepository $categoryPropertyRepository,
@@ -53,7 +55,9 @@ class ProcessorDecorator implements ItemProcessorInterface
         if ($categoryProperties !== null) {
             $categoryData = array_merge(
                 $categoryData,
-                $this->standardToFlat->convert($categoryProperties->getProperties())
+                $this->transformerManager->transformOnNormalized(
+                    $this->standardToFlat->convert($categoryProperties->getProperties())
+                )
             );
         }
 

--- a/src/DependencyInjection/CompilerPass/DataTransformerCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/DataTransformerCompilerPass.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Flagbit\Bundle\CategoryBundle\DependencyInjection\CompilerPass;
 
-use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
-use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformerManager;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -17,11 +15,25 @@ class DataTransformerCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (! $container->has(NormalizationTransformerManager::class)) {
+        if ($container->has('flagbit.category.data_transformer.normalization_transformer_manager')) {
+            $this->collectNormalizationTransformers($container);
+        }
+
+        if (! $container->has('flagbit.category.data_transformer.denormalization_transformer_manager')) {
             return;
         }
 
-        $normalizationDefinition = $container->findDefinition(NormalizationTransformerManager::class);
+        $this->collectDenormalizationTransformers($container);
+    }
+
+    /**
+     * Collect all normalization transformers and register them.
+     */
+    private function collectNormalizationTransformers(ContainerBuilder $container): void
+    {
+        $normalizationDefinition = $container->findDefinition(
+            'flagbit.category.data_transformer.normalization_transformer_manager'
+        );
         $taggedServices          = $container->findTaggedServiceIds(
             'flagbit.category.data_transformer.normalization'
         );
@@ -33,8 +45,16 @@ class DataTransformerCompilerPass implements CompilerPassInterface
                 ]);
             }
         }
+    }
 
-        $denormalizationDefinition = $container->findDefinition(DenormalizationTransformer::class);
+    /**
+     * Collect all denormalization transformers and register them.
+     */
+    private function collectDenormalizationTransformers(ContainerBuilder $container): void
+    {
+        $denormalizationDefinition = $container->findDefinition(
+            'flagbit.category.data_transformer.denormalization_transformer_manager'
+        );
         $taggedServices            = $container->findTaggedServiceIds(
             'flagbit.category.data_transformer.denormalization'
         );

--- a/src/DependencyInjection/CompilerPass/DataTransformerCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/DataTransformerCompilerPass.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\DependencyInjection\CompilerPass;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformerManager;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass to pass {@see NormalizationTransformer}s to the {@see NormalizationTransformerManager}.
+ */
+class DataTransformerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (! $container->has(NormalizationTransformerManager::class)) {
+            return;
+        }
+
+        $normalizationDefinition = $container->findDefinition(NormalizationTransformerManager::class);
+        $taggedServices          = $container->findTaggedServiceIds(
+            'flagbit.category.data_transformer.normalization'
+        );
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $normalizationDefinition->addMethodCall('addTransformer', [
+                    new Reference($id),
+                    $attributes['type'],
+                ]);
+            }
+        }
+
+        $denormalizationDefinition = $container->findDefinition(DenormalizationTransformer::class);
+        $taggedServices            = $container->findTaggedServiceIds(
+            'flagbit.category.data_transformer.denormalization'
+        );
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $denormalizationDefinition->addMethodCall('addTransformer', [
+                    new Reference($id),
+                    $attributes['type'],
+                ]);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/FlagbitCategoryExtension.php
+++ b/src/DependencyInjection/FlagbitCategoryExtension.php
@@ -25,5 +25,6 @@ class FlagbitCategoryExtension extends Extension
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
+        $loader->load('category_property_transformers.yml');
     }
 }

--- a/src/EventListener/BulkSavePropertyListener.php
+++ b/src/EventListener/BulkSavePropertyListener.php
@@ -62,6 +62,8 @@ class BulkSavePropertyListener
                 return;
             }
 
+
+
             if ($this->validator->validate($properties) !== []) {
                 throw ValidationFailed::invalidPropertyJsonFormat();
             }

--- a/src/EventListener/BulkSavePropertyListener.php
+++ b/src/EventListener/BulkSavePropertyListener.php
@@ -62,8 +62,6 @@ class BulkSavePropertyListener
                 return;
             }
 
-
-
             if ($this->validator->validate($properties) !== []) {
                 throw ValidationFailed::invalidPropertyJsonFormat();
             }

--- a/src/FlagbitCategoryBundle.php
+++ b/src/FlagbitCategoryBundle.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace Flagbit\Bundle\CategoryBundle;
 
+use Flagbit\Bundle\CategoryBundle\DependencyInjection\CompilerPass\DataTransformerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class FlagbitCategoryBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DataTransformerCompilerPass());
+    }
 }

--- a/src/Repository/CategoryConfigRepository.php
+++ b/src/Repository/CategoryConfigRepository.php
@@ -5,7 +5,21 @@ declare(strict_types=1);
 namespace Flagbit\Bundle\CategoryBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
 
 class CategoryConfigRepository extends EntityRepository
 {
+    /**
+     * Find the configuration of the category properties.
+     *
+     * Defaults to 1 as the identifier of the category config row.
+     * If there is no such database row, a new instance of {@see CategoryConfig} is returned.
+     */
+    public function findConfig(int $identifier = 1): CategoryConfig
+    {
+        /** @phpstan-var CategoryConfig|null $categoryConfig */
+        $categoryConfig = $this->find($identifier);
+
+        return $categoryConfig ?? new CategoryConfig([]);
+    }
 }

--- a/src/Resources/config/category_property_transformers.yml
+++ b/src/Resources/config/category_property_transformers.yml
@@ -1,0 +1,24 @@
+services:
+  flagbit.category.data_transformer.denormalization.default:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\DefaultTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.denormalization'
+        type: 'default'
+
+  flagbit.category.data_transformer.normalization.default:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\DefaultTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.normalization'
+        type: 'default'
+
+  flagbit.category.data_transformer.normalization.checkbox:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\BooleanTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.normalization'
+        type: 'checkbox'
+
+  flagbit.category.data_transformer.denormalization.checkbox:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\BooleanTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.denormalization'
+        type: 'checkbox'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -111,27 +111,3 @@ services:
     class: 'Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformerManager'
     arguments:
       - '@flagbit.category.repository.category_config'
-
-  flagbit.category.data_transformer.denormalization.default:
-    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\DefaultTransformer'
-    tags:
-      - name: 'flagbit.category.data_transformer.denormalization'
-        type: 'default'
-
-  flagbit.category.data_transformer.normalization.default:
-    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\DefaultTransformer'
-    tags:
-      - name: 'flagbit.category.data_transformer.normalization'
-        type: 'default'
-
-  flagbit.category.data_transformer.normalization.checkbox:
-    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\BooleanTransformer'
-    tags:
-      - name: 'flagbit.category.data_transformer.normalization'
-        type: 'checkbox'
-
-  flagbit.category.data_transformer.denormalization.checkbox:
-    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\BooleanTransformer'
-    tags:
-      - name: 'flagbit.category.data_transformer.denormalization'
-        type: 'checkbox'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -74,6 +74,14 @@ services:
       - '@flagbit.category.converter.standard_to_flat.category_property'
       - '@flagbit.category.processor.normalization.category.inner'
 
+  flagbit.category.processor.denormalization.category:
+    class: 'Flagbit\Bundle\CategoryBundle\Connector\Processor\Denormalization\ProcessorDecorator'
+    decorates: 'pim_connector.processor.denormalization.category'
+    decoration_inner_name: 'flagbit.category.processor.denormalization.category.inner'
+    arguments:
+      - '@flagbit.category.processor.denormalization.category.inner'
+      - '@flagbit.category.properties_bag'
+
   flagbit.category.array_converter.flat_to_standard.category:
     class: 'Flagbit\Bundle\CategoryBundle\Connector\ArrayConverter\FlatToStandard\CategoryDecorator'
     decorates: 'pim_connector.array_converter.flat_to_standard.category'
@@ -91,3 +99,25 @@ services:
     class: 'Flagbit\Bundle\CategoryBundle\Schema\SchemaValidator'
     arguments:
       - '../Resources/config/schema/config.json'
+
+  flagbit.category.data_transformer.normalization_transformer_manager:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformerManager'
+    arguments:
+      - '@flagbit.category.repository.category_config'
+
+  flagbit.category.data_transformer.denormalization_transformer_manager:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformerManager'
+    arguments:
+      - '@flagbit.category.repository.category_config'
+
+  flagbit.category.data_transformer.denormalization.default:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\DefaultTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.denormalization'
+        type: ['default']
+
+  flagbit.category.data_transformer.normalization.default:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\DefaultTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.normalization'
+        type: ['default']

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -123,3 +123,15 @@ services:
     tags:
       - name: 'flagbit.category.data_transformer.normalization'
         type: 'default'
+
+  flagbit.category.data_transformer.normalization.checkbox:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\BooleanTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.normalization'
+        type: 'checkbox'
+
+  flagbit.category.data_transformer.denormalization.checkbox:
+    class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\BooleanTransformer'
+    tags:
+      - name: 'flagbit.category.data_transformer.denormalization'
+        type: 'checkbox'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -73,6 +73,7 @@ services:
       - '@flagbit.category.repository.category_property'
       - '@flagbit.category.converter.standard_to_flat.category_property'
       - '@flagbit.category.processor.normalization.category.inner'
+      - '@flagbit.category.data_transformer.normalization_transformer_manager'
 
   flagbit.category.processor.denormalization.category:
     class: 'Flagbit\Bundle\CategoryBundle\Connector\Processor\Denormalization\ProcessorDecorator'
@@ -80,6 +81,7 @@ services:
     decoration_inner_name: 'flagbit.category.processor.denormalization.category.inner'
     arguments:
       - '@flagbit.category.processor.denormalization.category.inner'
+      - '@flagbit.category.data_transformer.denormalization_transformer_manager'
       - '@flagbit.category.properties_bag'
 
   flagbit.category.array_converter.flat_to_standard.category:
@@ -114,10 +116,10 @@ services:
     class: 'Flagbit\Bundle\CategoryBundle\Transformer\Denormalization\DefaultTransformer'
     tags:
       - name: 'flagbit.category.data_transformer.denormalization'
-        type: ['default']
+        type: 'default'
 
   flagbit.category.data_transformer.normalization.default:
     class: 'Flagbit\Bundle\CategoryBundle\Transformer\Normalization\DefaultTransformer'
     tags:
       - name: 'flagbit.category.data_transformer.normalization'
-        type: ['default']
+        type: 'default'

--- a/src/Transformer/Denormalization/BooleanTransformer.php
+++ b/src/Transformer/Denormalization/BooleanTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer\Denormalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
+
+/**
+ * Transformer that handles proper normalization of boolean values.
+ */
+class BooleanTransformer implements DenormalizationTransformer
+{
+    /**
+     * Convert passed data to an int representing the boolean value of the data (0 / 1).
+     *
+     * @param mixed $data
+     */
+    public function transform($data): int
+    {
+        return (int) ((bool) $data);
+    }
+}

--- a/src/Transformer/Denormalization/BooleanTransformer.php
+++ b/src/Transformer/Denormalization/BooleanTransformer.php
@@ -14,10 +14,10 @@ class BooleanTransformer implements DenormalizationTransformer
     /**
      * Convert passed data to an int representing the boolean value of the data (0 / 1).
      *
-     * @param mixed $data
+     * @phpstan-param bool $data
      */
-    public function transform($data): int
+    public function transform($data): bool
     {
-        return (int) ((bool) $data);
+        return (bool) $data;
     }
 }

--- a/src/Transformer/Denormalization/BooleanTransformer.php
+++ b/src/Transformer/Denormalization/BooleanTransformer.php
@@ -14,7 +14,7 @@ class BooleanTransformer implements DenormalizationTransformer
     /**
      * Convert passed data to an int representing the boolean value of the data (0 / 1).
      *
-     * @phpstan-param bool $data
+     * @phpstan-param string $data
      */
     public function transform($data): bool
     {

--- a/src/Transformer/Denormalization/BooleanTransformer.php
+++ b/src/Transformer/Denormalization/BooleanTransformer.php
@@ -13,10 +13,8 @@ class BooleanTransformer implements DenormalizationTransformer
 {
     /**
      * Convert passed data to a boolean representing the boolean value of the data.
-     *
-     * @phpstan-param string $data
      */
-    public function transform($data): bool
+    public function transform(string $data): bool
     {
         return (bool) $data;
     }

--- a/src/Transformer/Denormalization/BooleanTransformer.php
+++ b/src/Transformer/Denormalization/BooleanTransformer.php
@@ -12,7 +12,7 @@ use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
 class BooleanTransformer implements DenormalizationTransformer
 {
     /**
-     * Convert passed data to an int representing the boolean value of the data (0 / 1).
+     * Convert passed data to a boolean representing the boolean value of the data.
      *
      * @phpstan-param string $data
      */

--- a/src/Transformer/Denormalization/DefaultTransformer.php
+++ b/src/Transformer/Denormalization/DefaultTransformer.php
@@ -13,10 +13,8 @@ class DefaultTransformer implements DenormalizationTransformer
 {
     /**
      * @phpstan-param mixed $data
-     *
-     * @return mixed
      */
-    public function transform($data)
+    public function transform(string $data)
     {
         return $data;
     }

--- a/src/Transformer/Denormalization/DefaultTransformer.php
+++ b/src/Transformer/Denormalization/DefaultTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer\Denormalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
+
+/**
+ * Default denormalization transformer that applies no changes.
+ */
+class DefaultTransformer implements DenormalizationTransformer
+{
+    /**
+     * @phpstan-param mixed $data
+     *
+     * @return mixed
+     */
+    public function transform($data)
+    {
+        return $data;
+    }
+}

--- a/src/Transformer/Denormalization/DefaultTransformer.php
+++ b/src/Transformer/Denormalization/DefaultTransformer.php
@@ -11,10 +11,7 @@ use Flagbit\Bundle\CategoryBundle\Transformer\DenormalizationTransformer;
  */
 class DefaultTransformer implements DenormalizationTransformer
 {
-    /**
-     * @phpstan-param mixed $data
-     */
-    public function transform(string $data)
+    public function transform(string $data): string
     {
         return $data;
     }

--- a/src/Transformer/DenormalizationTransformer.php
+++ b/src/Transformer/DenormalizationTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer;
+
+/**
+ * Interface for denormalization category property data transformers.
+ */
+interface DenormalizationTransformer
+{
+    /**
+     * Apply transformations to the supplied data on import.
+     *
+     * @param mixed $data a single property value
+     *
+     * @return mixed
+     */
+    public function transform($data);
+}

--- a/src/Transformer/DenormalizationTransformer.php
+++ b/src/Transformer/DenormalizationTransformer.php
@@ -12,9 +12,7 @@ interface DenormalizationTransformer
     /**
      * Apply transformations to the supplied data on import.
      *
-     * @param mixed $data a single property value
-     *
      * @return mixed
      */
-    public function transform($data);
+    public function transform(string $data);
 }

--- a/src/Transformer/DenormalizationTransformerManager.php
+++ b/src/Transformer/DenormalizationTransformerManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flagbit\Bundle\CategoryBundle\Transformer;
 
-use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
 
 /**
@@ -23,8 +22,7 @@ use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
  */
 class DenormalizationTransformerManager
 {
-    public const DEFAULT_NORMALIZATION_TRANSFORMER   = 'default';
-    private const DEFAULT_PROPERTY_CONFIG_IDENTIFIER = 1;
+    public const DEFAULT_NORMALIZATION_TRANSFORMER = 'default';
 
     private CategoryConfigRepository $categoryConfigRepository;
 
@@ -45,7 +43,7 @@ class DenormalizationTransformerManager
      */
     public function transformOnDenormalized(array $properties): array
     {
-        $propertyConfig = $this->findConfig();
+        $propertyConfig = $this->categoryConfigRepository->findConfig();
         foreach ($propertyConfig->getConfig() as $property => $config) {
             if (! isset($properties[$property])) {
                 continue;
@@ -60,14 +58,6 @@ class DenormalizationTransformerManager
         }
 
         return $properties;
-    }
-
-    private function findConfig(): CategoryConfig
-    {
-        /** @phpstan-var CategoryConfig|null $categoryConfig */
-        $categoryConfig = $this->categoryConfigRepository->find(self::DEFAULT_PROPERTY_CONFIG_IDENTIFIER);
-
-        return $categoryConfig ?? new CategoryConfig([]);
     }
 
     /**

--- a/src/Transformer/DenormalizationTransformerManager.php
+++ b/src/Transformer/DenormalizationTransformerManager.php
@@ -29,7 +29,7 @@ class DenormalizationTransformerManager
     private CategoryConfigRepository $categoryConfigRepository;
 
     /** @var array<string, DenormalizationTransformer> */
-    private array $dataTransformers;
+    private array $dataTransformers = [];
 
     public function __construct(CategoryConfigRepository $categoryConfigRepository)
     {
@@ -71,14 +71,12 @@ class DenormalizationTransformerManager
     }
 
     /**
-     * Add a new import transformer to the registered transformers
+     * Add a new denormalization transformer to the registered transformers
      *
-     * @param string[] $types on which the transformer should be applied
+     * @param string $type on which the transformer should be applied
      */
-    public function addTransformer(DenormalizationTransformer $transformer, array $types): void
+    public function addTransformer(DenormalizationTransformer $transformer, string $type): void
     {
-        foreach ($types as $type) {
-            $this->dataTransformers[$type] = $transformer;
-        }
+        $this->dataTransformers[$type] = $transformer;
     }
 }

--- a/src/Transformer/DenormalizationTransformerManager.php
+++ b/src/Transformer/DenormalizationTransformerManager.php
@@ -23,8 +23,8 @@ use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
  */
 class DenormalizationTransformerManager
 {
+    public const DEFAULT_NORMALIZATION_TRANSFORMER   = 'default';
     private const DEFAULT_PROPERTY_CONFIG_IDENTIFIER = 1;
-    private const DEFAULT_NORMALIZATION_TRANSFORMER  = 'default';
 
     private CategoryConfigRepository $categoryConfigRepository;
 

--- a/src/Transformer/DenormalizationTransformerManager.php
+++ b/src/Transformer/DenormalizationTransformerManager.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer;
+
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
+use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
+
+/**
+ * Handle property denormalization transformer registration and execution.
+ *
+ * This class handles the registration and execution of denormalization transformers, that allow
+ * to apply custom logic for specific property types during denormalization.
+ *
+ * Symfony service tags are used to register new transformers.
+ * The tag used to register a service as a denormalization transformer
+ * is "flagbit.category.data_transformer.denormalization".
+ * A "type" attribute must be passed with the tag, that defines on which property type the
+ * transformer should be applied.
+ *
+ * Transformers must implement the {@see DenormalizationTransformer} interface.
+ */
+class DenormalizationTransformerManager
+{
+    private const DEFAULT_PROPERTY_CONFIG_IDENTIFIER = 1;
+    private const DEFAULT_NORMALIZATION_TRANSFORMER  = 'default';
+
+    private CategoryConfigRepository $categoryConfigRepository;
+
+    /** @var array<string, DenormalizationTransformer> */
+    private array $dataTransformers;
+
+    public function __construct(CategoryConfigRepository $categoryConfigRepository)
+    {
+        $this->categoryConfigRepository = $categoryConfigRepository;
+    }
+
+    /**
+     * Transform a single property set for a category received during denormalization.
+     *
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>
+     */
+    public function transformOnDenormalized(array $properties): array
+    {
+        $propertyConfig = $this->findConfig();
+        foreach ($propertyConfig->getConfig() as $property => $config) {
+            if (! isset($properties[$property])) {
+                continue;
+            }
+
+            $transformer = $this->dataTransformers[$config['type']]
+                ?? $this->dataTransformers[self::DEFAULT_NORMALIZATION_TRANSFORMER];
+
+            foreach ($properties[$property] as $locale => $value) {
+                $properties[$property][$locale]['data'] = $transformer->transform($value['data']);
+            }
+        }
+
+        return $properties;
+    }
+
+    private function findConfig(): CategoryConfig
+    {
+        /** @phpstan-var CategoryConfig|null $categoryConfig */
+        $categoryConfig = $this->categoryConfigRepository->find(self::DEFAULT_PROPERTY_CONFIG_IDENTIFIER);
+
+        return $categoryConfig ?? new CategoryConfig([]);
+    }
+
+    /**
+     * Add a new import transformer to the registered transformers
+     *
+     * @param string[] $types on which the transformer should be applied
+     */
+    public function addTransformer(DenormalizationTransformer $transformer, array $types): void
+    {
+        foreach ($types as $type) {
+            $this->dataTransformers[$type] = $transformer;
+        }
+    }
+}

--- a/src/Transformer/Normalization/BooleanTransformer.php
+++ b/src/Transformer/Normalization/BooleanTransformer.php
@@ -12,12 +12,12 @@ use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformer;
 class BooleanTransformer implements NormalizationTransformer
 {
     /**
-     * Convert passed data to a int representing the boolean value of the data (0 / 1).
+     * Convert passed data to a string representing the boolean value of the data (0 / 1).
      *
-     * @param mixed $data
+     * @phpstan-param bool $data
      */
-    public function transform($data): int
+    public function transform($data): string
     {
-        return (int) ((bool) $data);
+        return $data ? '1' : '0';
     }
 }

--- a/src/Transformer/Normalization/BooleanTransformer.php
+++ b/src/Transformer/Normalization/BooleanTransformer.php
@@ -15,6 +15,8 @@ class BooleanTransformer implements NormalizationTransformer
      * Convert passed data to a string representing the boolean value of the data (0 / 1).
      *
      * @phpstan-param bool $data
+     *
+     * @phpstan-return numeric-string
      */
     public function transform($data): string
     {

--- a/src/Transformer/Normalization/BooleanTransformer.php
+++ b/src/Transformer/Normalization/BooleanTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer\Normalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformer;
+
+/**
+ * Transformer that handles proper normalization of boolean values.
+ */
+class BooleanTransformer implements NormalizationTransformer
+{
+    /**
+     * Convert passed data to a int representing the boolean value of the data (0 / 1).
+     *
+     * @param mixed $data
+     */
+    public function transform($data): int
+    {
+        return (int) ((bool) $data);
+    }
+}

--- a/src/Transformer/Normalization/DefaultTransformer.php
+++ b/src/Transformer/Normalization/DefaultTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer\Normalization;
+
+use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformer;
+
+/**
+ * Default normalization transformer that applies no changes.
+ */
+class DefaultTransformer implements NormalizationTransformer
+{
+    /**
+     * @phpstan-param mixed $data
+     *
+     * @return mixed
+     */
+    public function transform($data)
+    {
+        return $data;
+    }
+}

--- a/src/Transformer/Normalization/DefaultTransformer.php
+++ b/src/Transformer/Normalization/DefaultTransformer.php
@@ -12,11 +12,9 @@ use Flagbit\Bundle\CategoryBundle\Transformer\NormalizationTransformer;
 class DefaultTransformer implements NormalizationTransformer
 {
     /**
-     * @phpstan-param mixed $data
-     *
-     * @return mixed
+     * @phpstan-param mixed $data data that can be cast to string
      */
-    public function transform($data)
+    public function transform($data): string
     {
         return $data;
     }

--- a/src/Transformer/NormalizationTransformer.php
+++ b/src/Transformer/NormalizationTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer;
+
+/**
+ * Interface for normalization category property data transformers.
+ */
+interface NormalizationTransformer
+{
+    /**
+     * Apply transformations to the supplied data on import.
+     *
+     * @param mixed $data a single property value
+     *
+     * @return mixed
+     */
+    public function transform($data);
+}

--- a/src/Transformer/NormalizationTransformer.php
+++ b/src/Transformer/NormalizationTransformer.php
@@ -13,8 +13,6 @@ interface NormalizationTransformer
      * Apply transformations to the supplied data on import.
      *
      * @param mixed $data a single property value
-     *
-     * @return mixed
      */
-    public function transform($data);
+    public function transform($data): string;
 }

--- a/src/Transformer/NormalizationTransformerManager.php
+++ b/src/Transformer/NormalizationTransformerManager.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Bundle\CategoryBundle\Transformer;
+
+use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
+use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
+
+/**
+ * Handle property normalization transformer registration and execution.
+ *
+ * This class handles the registration and execution of normalization transformers, that allow
+ * to apply custom logic for specific property types during normalization.
+ *
+ * Symfony service tags are used to register new transformers.
+ * The tag used to register a service as a normalization transformer
+ * is "flagbit.category.data_transformer.denormalization".
+ * A "type" attribute must be passed with the tag, that defines on which property type the
+ * transformer should be applied.
+ *
+ * Transformers must implement the {@see NormalizationTransformer} interface.
+ */
+class NormalizationTransformerManager
+{
+    private const DEFAULT_PROPERTY_CONFIG_IDENTIFIER = 1;
+    private const DEFAULT_NORMALIZATION_TRANSFORMER  = 'default';
+
+    private CategoryConfigRepository $categoryConfigRepository;
+
+    /** @var array<string, NormalizationTransformer> */
+    private array $dataTransformers;
+
+    public function __construct(CategoryConfigRepository $categoryConfigRepository)
+    {
+        $this->categoryConfigRepository = $categoryConfigRepository;
+    }
+
+    /**
+     * Transform a single property set for a category received during denormalization.
+     *
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>
+     */
+    public function transformOnNormalized(array $properties): array
+    {
+        $propertyConfig = $this->findConfig();
+        foreach ($propertyConfig->getConfig() as $property => $config) {
+            if (! isset($properties[$property])) {
+                continue;
+            }
+
+            $transformer = $this->dataTransformers[$config['type']]
+                ?? $this->dataTransformers[self::DEFAULT_NORMALIZATION_TRANSFORMER];
+
+            foreach ($properties[$property] as $locale => $value) {
+                $properties[$property][$locale]['data'] = $transformer->transform($value['data']);
+            }
+        }
+
+        return $properties;
+    }
+
+    private function findConfig(): CategoryConfig
+    {
+        /** @phpstan-var CategoryConfig|null $categoryConfig */
+        $categoryConfig = $this->categoryConfigRepository->find(self::DEFAULT_PROPERTY_CONFIG_IDENTIFIER);
+
+        return $categoryConfig ?? new CategoryConfig([]);
+    }
+
+    /**
+     * Add a new import transformer to the registered transformers
+     *
+     * @param string[] $types on which the transformer should be applied
+     */
+    public function addTransformer(NormalizationTransformer $transformer, array $types): void
+    {
+        foreach ($types as $type) {
+            $this->dataTransformers[$type] = $transformer;
+        }
+    }
+}

--- a/src/Transformer/NormalizationTransformerManager.php
+++ b/src/Transformer/NormalizationTransformerManager.php
@@ -24,7 +24,6 @@ use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
 class NormalizationTransformerManager
 {
     public const DEFAULT_NORMALIZATION_TRANSFORMER   = 'default';
-    private const DEFAULT_PROPERTY_CONFIG_IDENTIFIER = 1;
 
     private CategoryConfigRepository $categoryConfigRepository;
 
@@ -45,7 +44,7 @@ class NormalizationTransformerManager
      */
     public function transformOnNormalized(array $properties): array
     {
-        $propertyConfig = $this->findConfig();
+        $propertyConfig = $this->categoryConfigRepository->findConfig();
         foreach ($propertyConfig->getConfig() as $property => $config) {
             if (! isset($properties[$property])) {
                 continue;
@@ -60,14 +59,6 @@ class NormalizationTransformerManager
         }
 
         return $properties;
-    }
-
-    private function findConfig(): CategoryConfig
-    {
-        /** @phpstan-var CategoryConfig|null $categoryConfig */
-        $categoryConfig = $this->categoryConfigRepository->find(self::DEFAULT_PROPERTY_CONFIG_IDENTIFIER);
-
-        return $categoryConfig ?? new CategoryConfig([]);
     }
 
     /**

--- a/src/Transformer/NormalizationTransformerManager.php
+++ b/src/Transformer/NormalizationTransformerManager.php
@@ -29,7 +29,7 @@ class NormalizationTransformerManager
     private CategoryConfigRepository $categoryConfigRepository;
 
     /** @var array<string, NormalizationTransformer> */
-    private array $dataTransformers;
+    private array $dataTransformers = [];
 
     public function __construct(CategoryConfigRepository $categoryConfigRepository)
     {
@@ -71,14 +71,12 @@ class NormalizationTransformerManager
     }
 
     /**
-     * Add a new import transformer to the registered transformers
+     * Add a new normalization transformer to the registered transformers
      *
-     * @param string[] $types on which the transformer should be applied
+     * @param string $type on which the transformer should be applied
      */
-    public function addTransformer(NormalizationTransformer $transformer, array $types): void
+    public function addTransformer(NormalizationTransformer $transformer, string $type): void
     {
-        foreach ($types as $type) {
-            $this->dataTransformers[$type] = $transformer;
-        }
+        $this->dataTransformers[$type] = $transformer;
     }
 }

--- a/src/Transformer/NormalizationTransformerManager.php
+++ b/src/Transformer/NormalizationTransformerManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flagbit\Bundle\CategoryBundle\Transformer;
 
-use Flagbit\Bundle\CategoryBundle\Entity\CategoryConfig;
 use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
 
 /**
@@ -23,7 +22,7 @@ use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
  */
 class NormalizationTransformerManager
 {
-    public const DEFAULT_NORMALIZATION_TRANSFORMER   = 'default';
+    public const DEFAULT_NORMALIZATION_TRANSFORMER = 'default';
 
     private CategoryConfigRepository $categoryConfigRepository;
 

--- a/src/Transformer/NormalizationTransformerManager.php
+++ b/src/Transformer/NormalizationTransformerManager.php
@@ -23,8 +23,8 @@ use Flagbit\Bundle\CategoryBundle\Repository\CategoryConfigRepository;
  */
 class NormalizationTransformerManager
 {
+    public const DEFAULT_NORMALIZATION_TRANSFORMER   = 'default';
     private const DEFAULT_PROPERTY_CONFIG_IDENTIFIER = 1;
-    private const DEFAULT_NORMALIZATION_TRANSFORMER  = 'default';
 
     private CategoryConfigRepository $categoryConfigRepository;
 


### PR DESCRIPTION
Implement data transformers that allow to modify data during normalization and denormalization. This enables custom properties with custom data formats that could not be handled by the default import/export.

Test Cases

- Check if the category import sill works and imports data as expected.
- Check if the category export still works and exports data  as expected
- Check the import and export with a "checkbox" that uses a custom transformer by default
  - Import works as expected
  - Export works as expected